### PR TITLE
Add color picker to the LVGL code

### DIFF
--- a/lv_conf.h
+++ b/lv_conf.h
@@ -450,7 +450,7 @@ typedef void * lv_obj_user_data_t;
 #define LV_USE_CONT     1
 
 /*Color picker (dependencies: -*/
-#define LV_USE_CPICKER   0
+#define LV_USE_CPICKER   1
 
 /*Drop down list (dependencies: lv_page, lv_label, lv_symbol_def.h)*/
 #define LV_USE_DDLIST    1

--- a/src/lv_objx/lv_cpicker.c
+++ b/src/lv_objx/lv_cpicker.c
@@ -523,11 +523,11 @@ static void draw_disc_grad(lv_obj_t * cpicker, const lv_area_t * mask, lv_opa_t 
     lv_style_copy(&style, &lv_style_plain);
     uint16_t i;
     uint32_t a = 0;
-    style.line->width = (r * 628 / (256 / LV_CPICKER_DEF_QF)) / 100 + 2;
+    style.line.width = (r * 628 / (256 / LV_CPICKER_DEF_QF)) / 100 + 2;
 
     /* The inner line ends will be masked out.
      * So make lines a little bit longer because the masking makes a more even result */
-    lv_coord_t cir_w_extra = cir_w + line_dsc.width;
+    lv_coord_t cir_w_extra = style.line.width;
 
     for(i = 0; i <= 256; i += LV_CPICKER_DEF_QF, a += 360 * LV_CPICKER_DEF_QF) {
         style.body.main_color = angle_to_mode_color_fast(cpicker, i);
@@ -535,10 +535,10 @@ static void draw_disc_grad(lv_obj_t * cpicker, const lv_area_t * mask, lv_opa_t 
         uint16_t angle_trigo = (uint16_t)(a >> 8); /* i * 360 / 256 is the scale to apply, but we can skip multiplication here */
  
         lv_point_t p[2];
-        p[0].x = cx + (r * _lv_trigo_sin(angle_trigo) >> LV_TRIGO_SHIFT);
-        p[0].y = cy + (r * _lv_trigo_sin(angle_trigo + 90) >> LV_TRIGO_SHIFT);
-        p[1].x = cx + ((r - cir_w_extra) * _lv_trigo_sin(angle_trigo) >> LV_TRIGO_SHIFT);
-        p[1].y = cy + ((r - cir_w_extra) * _lv_trigo_sin(angle_trigo + 90) >> LV_TRIGO_SHIFT);
+        p[0].x = cx + (r * lv_trigo_sin(angle_trigo) >> LV_TRIGO_SHIFT);
+        p[0].y = cy + (r * lv_trigo_sin(angle_trigo + 90) >> LV_TRIGO_SHIFT);
+        p[1].x = cx + ((r - cir_w_extra) * lv_trigo_sin(angle_trigo) >> LV_TRIGO_SHIFT);
+        p[1].y = cy + ((r - cir_w_extra) * lv_trigo_sin(angle_trigo + 90) >> LV_TRIGO_SHIFT);
 
         lv_draw_line(&p[0], &p[1], mask, &style, LV_OPA_COVER);
     }
@@ -843,10 +843,6 @@ static lv_res_t lv_cpicker_signal(lv_obj_t * cpicker, lv_signal_t sign, void * p
             res = lv_event_send(cpicker, LV_EVENT_VALUE_CHANGED, NULL);
             if(res != LV_RES_OK) return res;
         }
-    }
-    else if(sign == LV_SIGNAL_HIT_TEST) {
-        lv_hit_test_info_t * info = param;
-        info->result = lv_cpicker_hit(cpicker, info->point);
     }
 
     return res;

--- a/src/lv_objx/lv_cpicker.h
+++ b/src/lv_objx/lv_cpicker.h
@@ -95,14 +95,6 @@ lv_obj_t * lv_cpicker_create(lv_obj_t * par, const lv_obj_t * copy);
 void lv_cpicker_set_type(lv_obj_t * cpicker, lv_cpicker_type_t type);
 
 /**
- * Set a style of a colorpicker.
- * @param cpicker pointer to colorpicker object
- * @param type which style should be set
- * @param style pointer to a style
- */
-void lv_cpicker_set_style(lv_obj_t * cpicker, lv_cpicker_style_t type, lv_style_t *style);
-
-/**
  * Set the current hue of a colorpicker.
  * @param cpicker pointer to colorpicker object
  * @param hue current selected hue [0..360]
@@ -180,14 +172,6 @@ lv_cpicker_color_mode_t lv_cpicker_get_color_mode(lv_obj_t * cpicker);
  * @return mode cannot be changed on long press
  */
 bool lv_cpicker_get_color_mode_fixed(lv_obj_t * cpicker);
-
-/**
- * Get style of a colorpicker.
- * @param cpicker pointer to colorpicker object
- * @param type which style should be get
- * @return pointer to the style
- */
-const lv_style_t * lv_cpicker_get_style(const lv_obj_t * cpicker, lv_cpicker_style_t type);
 
 /**
  * Get the current hue of a colorpicker.

--- a/src/lv_objx/lv_cpicker.h
+++ b/src/lv_objx/lv_cpicker.h
@@ -95,6 +95,14 @@ lv_obj_t * lv_cpicker_create(lv_obj_t * par, const lv_obj_t * copy);
 void lv_cpicker_set_type(lv_obj_t * cpicker, lv_cpicker_type_t type);
 
 /**
+ * Set a style of a colorpicker.
+ * @param cpicker pointer to colorpicker object
+ * @param type which style should be set
+ * @param style pointer to a style
+ */
+void lv_cpicker_set_style(lv_obj_t * cpicker, lv_cpicker_style_t type, lv_style_t *style);
+
+/**
  * Set the current hue of a colorpicker.
  * @param cpicker pointer to colorpicker object
  * @param hue current selected hue [0..360]
@@ -158,6 +166,14 @@ void lv_cpicker_set_knob_colored(lv_obj_t * cpicker, bool en);
 /*=====================
  * Getter functions
  *====================*/
+
+/**
+ * Get style of a colorpicker.
+ * @param cpicker pointer to colorpicker object
+ * @param type which style should be get
+ * @return pointer to the style
+ */
+const lv_style_t * lv_cpicker_get_style(const lv_obj_t * cpicker, lv_cpicker_style_t type);
 
 /**
  * Get the current color mode.

--- a/src/lv_objx/lv_cpicker.h
+++ b/src/lv_objx/lv_cpicker.h
@@ -54,20 +54,19 @@ typedef struct {
         lv_point_t pos;
         uint8_t colored     :1;
 
-    } indic;
+    } knob;
     uint32_t last_click_time;
     uint32_t last_change_time;
     lv_point_t last_press_point;
-    lv_cpicker_color_mode_t color_mode  :2;
-    uint8_t color_mode_fixed            :1;
-    lv_cpicker_type_t type              :1;
-    uint8_t preview                     :1;
+    lv_cpicker_color_mode_t color_mode  : 2;
+    uint8_t color_mode_fixed            : 1;
+    lv_cpicker_type_t type              : 1;
 } lv_cpicker_ext_t;
 
-/*Styles*/
+/*Parts*/
 enum {
     LV_CPICKER_STYLE_MAIN,
-    LV_CPICKER_STYLE_INDICATOR,
+    LV_CPICKER_STYLE_KNOB,
 };
 typedef uint8_t lv_cpicker_style_t;
 
@@ -158,18 +157,11 @@ void lv_cpicker_set_color_mode(lv_obj_t * cpicker, lv_cpicker_color_mode_t mode)
 void lv_cpicker_set_color_mode_fixed(lv_obj_t * cpicker, bool fixed);
 
 /**
- * Make the indicator to be colored to the current color
+ * Make the knob to be colored to the current color
  * @param cpicker pointer to colorpicker object
- * @param en true: color the indicator; false: not color the indicator
+ * @param en true: color the knob; false: not color the knob
  */
-void lv_cpicker_set_indic_colored(lv_obj_t * cpicker, bool en);
-
-/**
- * Add a color preview in the middle of the DISC type color picker
- * @param cpicker pointer to colorpicker object
- * @param en true: enable preview; false: disable preview
- */
-void lv_cpicker_set_preview(lv_obj_t * cpicker, bool en);
+void lv_cpicker_set_knob_colored(lv_obj_t * cpicker, bool en);
 
 /*=====================
  * Getter functions
@@ -233,18 +225,11 @@ lv_color_hsv_t lv_cpicker_get_hsv(lv_obj_t * cpicker);
 lv_color_t lv_cpicker_get_color(lv_obj_t * cpicker);
 
 /**
- * Whether the indicator is colored to the current color or not
- * @param cpicker pointer to colorpicker object
- * @return true: color the indicator; false: not color the indicator
+ * Whether the knob is colored to the current color or not
+ * @param cpicker pointer to color picker object
+ * @return true: color the knob; false: not color the knob
  */
-bool lv_cpicker_get_indic_colored(lv_obj_t * cpicker);
-
-/**
- *  Whether the preview is enabled or not
- * @param cpicker pointer to colorpicker object
- * @return en true: preview is enabled; false: preview is disabled
- */
-bool lv_cpicker_get_preview(lv_obj_t * cpicker);
+bool lv_cpicker_get_knob_colored(lv_obj_t * cpicker);
 
 /*=====================
  * Other functions


### PR DESCRIPTION
I had to modify the code so it's working with this version of LVGL.
It was too slow initially to draw, so I've reworked the drawing code not to compute HSV to RGB for every triangle drawn.
The result is correct (but not perfect, that would require LVGL 7.11 or LVGL 8)

I've reworked the interactivity so it's possible to use it with the version in TFT35 that does not repeat keypress/touch event.

It's required for this [PR](https://github.com/MarlinFirmware/Marlin/pull/21158). 
Meanwhile, it's pointing to my repo, but once you've merge this, I'll update the PR so it points back to yours.
